### PR TITLE
Specify package versions and allow SDK roll forward

### DIFF
--- a/apps/TicTacToe.Blazor/TicTacToe.Blazor.csproj
+++ b/apps/TicTacToe.Blazor/TicTacToe.Blazor.csproj
@@ -7,8 +7,8 @@
     <RootNamespace>TicTacToeVibe.Blazor</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../libs/TicTacToe.Core/TicTacToe.Core.csproj" />

--- a/apps/TicTacToeVibe/TicTacToeVibe.csproj
+++ b/apps/TicTacToeVibe/TicTacToeVibe.csproj
@@ -9,10 +9,10 @@
     <RootNamespace>TicTacToeVibe.Wpf</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Mvvm" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" PrivateAssets="all" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../libs/TicTacToe.Core/TicTacToe.Core.csproj" />

--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100"
+    "version": "8.0.100",
+    "rollForward": "latestFeature"
   }
 }

--- a/libs/TicTacToe.Core/TicTacToe.Core.csproj
+++ b/libs/TicTacToe.Core/TicTacToe.Core.csproj
@@ -7,6 +7,6 @@
     <RootNamespace>TicTacToeVibe.Core</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/tests/TicTacToe.Core.Tests/TicTacToe.Core.Tests.csproj
+++ b/tests/TicTacToe.Core.Tests/TicTacToe.Core.Tests.csproj
@@ -6,10 +6,10 @@
     <RootNamespace>TicTacToeVibe.Core.Tests</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" PrivateAssets="all" />
-    <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.visualstudio" />
-    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0" PrivateAssets="all" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../libs/TicTacToe.Core/TicTacToe.Core.csproj" />


### PR DESCRIPTION
## Summary
- pin NuGet package versions for project dependencies
- add rollForward setting to global.json to allow newer .NET 8 SDKs

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bdea5ddab88332a821063d79472be8