### PR TITLE
Fix WPF command parameter type for cell clicks

### DIFF
--- a/apps/TicTacToeVibe/MainWindow.xaml
+++ b/apps/TicTacToeVibe/MainWindow.xaml
@@ -9,15 +9,15 @@
             <TextBlock Text="{Binding StatusText}" VerticalAlignment="Center"/>
         </StackPanel>
         <UniformGrid Rows="3" Columns="3">
-            <Button Content="{Binding Cells[0]}" Command="{Binding CellClickCommand}" CommandParameter="0" FontSize="32"/>
-            <Button Content="{Binding Cells[1]}" Command="{Binding CellClickCommand}" CommandParameter="1" FontSize="32"/>
-            <Button Content="{Binding Cells[2]}" Command="{Binding CellClickCommand}" CommandParameter="2" FontSize="32"/>
-            <Button Content="{Binding Cells[3]}" Command="{Binding CellClickCommand}" CommandParameter="3" FontSize="32"/>
-            <Button Content="{Binding Cells[4]}" Command="{Binding CellClickCommand}" CommandParameter="4" FontSize="32"/>
-            <Button Content="{Binding Cells[5]}" Command="{Binding CellClickCommand}" CommandParameter="5" FontSize="32"/>
-            <Button Content="{Binding Cells[6]}" Command="{Binding CellClickCommand}" CommandParameter="6" FontSize="32"/>
-            <Button Content="{Binding Cells[7]}" Command="{Binding CellClickCommand}" CommandParameter="7" FontSize="32"/>
-            <Button Content="{Binding Cells[8]}" Command="{Binding CellClickCommand}" CommandParameter="8" FontSize="32"/>
+            <Button Content="{Binding Cells[0]}" Command="{Binding CellClickCommand}" CommandParameter="{x:Int32 0}" FontSize="32"/>
+            <Button Content="{Binding Cells[1]}" Command="{Binding CellClickCommand}" CommandParameter="{x:Int32 1}" FontSize="32"/>
+            <Button Content="{Binding Cells[2]}" Command="{Binding CellClickCommand}" CommandParameter="{x:Int32 2}" FontSize="32"/>
+            <Button Content="{Binding Cells[3]}" Command="{Binding CellClickCommand}" CommandParameter="{x:Int32 3}" FontSize="32"/>
+            <Button Content="{Binding Cells[4]}" Command="{Binding CellClickCommand}" CommandParameter="{x:Int32 4}" FontSize="32"/>
+            <Button Content="{Binding Cells[5]}" Command="{Binding CellClickCommand}" CommandParameter="{x:Int32 5}" FontSize="32"/>
+            <Button Content="{Binding Cells[6]}" Command="{Binding CellClickCommand}" CommandParameter="{x:Int32 6}" FontSize="32"/>
+            <Button Content="{Binding Cells[7]}" Command="{Binding CellClickCommand}" CommandParameter="{x:Int32 7}" FontSize="32"/>
+            <Button Content="{Binding Cells[8]}" Command="{Binding CellClickCommand}" CommandParameter="{x:Int32 8}" FontSize="32"/>
         </UniformGrid>
     </DockPanel>
 </Window>


### PR DESCRIPTION
## Summary
- use integer command parameters for grid buttons to match `CellClickCommand`

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf09a67c483329c2f3011a4f1803d