### PR TITLE
Fix WPF board cells not updating

### DIFF
--- a/apps/TicTacToeVibe/MainWindowViewModel.cs
+++ b/apps/TicTacToeVibe/MainWindowViewModel.cs
@@ -1,5 +1,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using System.Collections.ObjectModel;
+using System.Linq;
 using TicTacToeVibe.Core;
 
 namespace TicTacToeVibe.Wpf;
@@ -17,12 +19,11 @@ public partial class MainWindowViewModel : ObservableObject
     {
         _game = game;
         _ai = ai;
-        Cells = new string[9];
         UpdateState();
     }
 
-    [ObservableProperty]
-    private string[] cells;
+    /// <summary>Cells displayed on the board.</summary>
+    public ObservableCollection<string> Cells { get; } = new(Enumerable.Repeat(string.Empty, 9));
 
     [ObservableProperty]
     private string statusText = string.Empty;


### PR DESCRIPTION
## Summary
- replace string array with ObservableCollection so WPF board updates when cells change

## Testing
- `dotnet test` *(fails: command not found: dotnet)*


------
https://chatgpt.com/codex/tasks/task_e_68bdf437b6a8833289bebd2e0405b3aa