### PR TITLE
Add neon win line to TicTacToe board

### DIFF
--- a/apps/TicTacToeVibe/MainWindow.xaml
+++ b/apps/TicTacToeVibe/MainWindow.xaml
@@ -1,6 +1,7 @@
 <Window x:Class="TicTacToeVibe.Wpf.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="clr-namespace:TicTacToeVibe.Wpf"
         Title="TicTacToeVibe"
         Width="360" Height="420"
         Background="{DynamicResource Brush.Background}"
@@ -83,6 +84,17 @@
         <Style x:Key="CellContainerStyle" TargetType="ContentPresenter">
             <Setter Property="Margin" Value="4"/>
         </Style>
+
+        <Style x:Key="WinLineStyle" TargetType="Line">
+            <Setter Property="Stroke" Value="{StaticResource Brush.Accent}"/>
+            <Setter Property="StrokeThickness" Value="6"/>
+            <Setter Property="Visibility" Value="Collapsed"/>
+            <Setter Property="Effect">
+                <Setter.Value>
+                    <DropShadowEffect Color="{StaticResource Color.Accent}" BlurRadius="10" ShadowDepth="0"/>
+                </Setter.Value>
+            </Setter>
+        </Style>
     </Window.Resources>
 
     <DockPanel Margin="12">
@@ -103,24 +115,117 @@
         </StackPanel>
 
         <!-- Board 3x3 -->
-        <ItemsControl ItemsSource="{Binding Cells}"
-                      AlternationCount="9"
-                      ItemContainerStyle="{StaticResource CellContainerStyle}"
-                      Focusable="False">
-            <ItemsControl.ItemsPanel>
-                <ItemsPanelTemplate>
-                    <UniformGrid Rows="3" Columns="3"/>
-                </ItemsPanelTemplate>
-            </ItemsControl.ItemsPanel>
-            <ItemsControl.ItemTemplate>
-                <DataTemplate>
-                    <Button Style="{StaticResource CellButton}"
-                            Content="{Binding}"
-                            Command="{Binding DataContext.CellClickCommand, RelativeSource={RelativeSource AncestorType=Window}}"
-                            CommandParameter="{Binding (ItemsControl.AlternationIndex),
-                                                       RelativeSource={RelativeSource AncestorType=ContentPresenter}}"/>
-                </DataTemplate>
-            </ItemsControl.ItemTemplate>
-        </ItemsControl>
+        <Grid Width="240" Height="240">
+            <ItemsControl x:Name="Board"
+                          ItemsSource="{Binding Cells}"
+                          AlternationCount="9"
+                          ItemContainerStyle="{StaticResource CellContainerStyle}"
+                          Focusable="False">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <UniformGrid Rows="3" Columns="3"/>
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <Button Style="{StaticResource CellButton}"
+                                Content="{Binding}"
+                                Command="{Binding DataContext.CellClickCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                                CommandParameter="{Binding (ItemsControl.AlternationIndex),
+                                                           RelativeSource={RelativeSource AncestorType=ContentPresenter}}"/>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+            <Canvas Width="240" Height="240" IsHitTestVisible="False">
+                <Line X1="0" Y1="40" X2="240" Y2="40">
+                    <Line.Style>
+                        <Style BasedOn="{StaticResource WinLineStyle}" TargetType="Line">
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding WinningLine}" Value="{x:Static local:WinningLine.Row0}">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Line.Style>
+                </Line>
+                <Line X1="0" Y1="120" X2="240" Y2="120">
+                    <Line.Style>
+                        <Style BasedOn="{StaticResource WinLineStyle}" TargetType="Line">
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding WinningLine}" Value="{x:Static local:WinningLine.Row1}">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Line.Style>
+                </Line>
+                <Line X1="0" Y1="200" X2="240" Y2="200">
+                    <Line.Style>
+                        <Style BasedOn="{StaticResource WinLineStyle}" TargetType="Line">
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding WinningLine}" Value="{x:Static local:WinningLine.Row2}">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Line.Style>
+                </Line>
+                <Line X1="40" Y1="0" X2="40" Y2="240">
+                    <Line.Style>
+                        <Style BasedOn="{StaticResource WinLineStyle}" TargetType="Line">
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding WinningLine}" Value="{x:Static local:WinningLine.Col0}">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Line.Style>
+                </Line>
+                <Line X1="120" Y1="0" X2="120" Y2="240">
+                    <Line.Style>
+                        <Style BasedOn="{StaticResource WinLineStyle}" TargetType="Line">
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding WinningLine}" Value="{x:Static local:WinningLine.Col1}">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Line.Style>
+                </Line>
+                <Line X1="200" Y1="0" X2="200" Y2="240">
+                    <Line.Style>
+                        <Style BasedOn="{StaticResource WinLineStyle}" TargetType="Line">
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding WinningLine}" Value="{x:Static local:WinningLine.Col2}">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Line.Style>
+                </Line>
+                <Line X1="0" Y1="0" X2="240" Y2="240">
+                    <Line.Style>
+                        <Style BasedOn="{StaticResource WinLineStyle}" TargetType="Line">
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding WinningLine}" Value="{x:Static local:WinningLine.DiagonalMain}">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Line.Style>
+                </Line>
+                <Line X1="0" Y1="240" X2="240" Y2="0">
+                    <Line.Style>
+                        <Style BasedOn="{StaticResource WinLineStyle}" TargetType="Line">
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding WinningLine}" Value="{x:Static local:WinningLine.DiagonalAnti}">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Line.Style>
+                </Line>
+            </Canvas>
+        </Grid>
     </DockPanel>
 </Window>

--- a/apps/TicTacToeVibe/MainWindowViewModel.cs
+++ b/apps/TicTacToeVibe/MainWindowViewModel.cs
@@ -34,6 +34,9 @@ public partial class MainWindowViewModel : ObservableObject
     [ObservableProperty]
     private bool isHumanVsAi = true;
 
+    [ObservableProperty]
+    private WinningLine winningLine = WinningLine.None;
+
     [RelayCommand(CanExecute = nameof(CanClick))]
     private void CellClick(int index)
     {
@@ -76,6 +79,9 @@ public partial class MainWindowViewModel : ObservableObject
                 _ => "Draw"
             }
             : $"Turn: {_game.Board.CurrentPlayer}";
+        WinningLine = _game.Board.IsGameOver && _game.Board.Winner is Player winner
+            ? FindWinningLine(_game.Board, winner)
+            : WinningLine.None;
         CellClickCommand.NotifyCanExecuteChanged();
     }
 
@@ -87,4 +93,40 @@ public partial class MainWindowViewModel : ObservableObject
     };
 
     private static Move ToMove(int index) => new(index / 3, index % 3);
+
+    private static WinningLine FindWinningLine(Board board, Player player)
+    {
+        for (var i = 0; i < 3; i++)
+        {
+            if (board[i, 0] == player && board[i, 1] == player && board[i, 2] == player)
+            {
+                return i switch
+                {
+                    0 => WinningLine.Row0,
+                    1 => WinningLine.Row1,
+                    _ => WinningLine.Row2,
+                };
+            }
+            if (board[0, i] == player && board[1, i] == player && board[2, i] == player)
+            {
+                return i switch
+                {
+                    0 => WinningLine.Col0,
+                    1 => WinningLine.Col1,
+                    _ => WinningLine.Col2,
+                };
+            }
+        }
+
+        if (board[0, 0] == player && board[1, 1] == player && board[2, 2] == player)
+        {
+            return WinningLine.DiagonalMain;
+        }
+        if (board[0, 2] == player && board[1, 1] == player && board[2, 0] == player)
+        {
+            return WinningLine.DiagonalAnti;
+        }
+
+        return WinningLine.None;
+    }
 }

--- a/apps/TicTacToeVibe/WinningLine.cs
+++ b/apps/TicTacToeVibe/WinningLine.cs
@@ -1,0 +1,17 @@
+namespace TicTacToeVibe.Wpf;
+
+/// <summary>
+/// Possible winning line positions on the Tic-Tac-Toe board.
+/// </summary>
+public enum WinningLine
+{
+    None,
+    Row0,
+    Row1,
+    Row2,
+    Col0,
+    Col1,
+    Col2,
+    DiagonalMain,
+    DiagonalAnti
+}


### PR DESCRIPTION
## Summary
- highlight winning row, column, or diagonal with neon accent line
- track and expose winning line in view model

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf6a6cab08332ab61313959aa99e8