### PR TITLE
Start game immediately with dark theme and win highlight

### DIFF
--- a/apps/TicTacToe.Blazor/Components/TicTacToeBoard.razor
+++ b/apps/TicTacToe.Blazor/Components/TicTacToeBoard.razor
@@ -10,18 +10,25 @@
 <div class="board">
     @for (var i = 0; i < 9; i++)
     {
-        <button disabled="@IsDisabled(i)" @onclick="(() => Click(i))" style="width:60px;height:60px;font-size:24px;">@cells[i]</button>
-        if ((i + 1) % 3 == 0)
-        {
-            <br />
-        }
+        <button class="cell" disabled="@IsDisabled(i)" @onclick="(() => Click(i))">@cells[i]</button>
     }
+    <svg class="win-lines">
+        <line x1="0" y1="40" x2="240" y2="40" class="@LineClass(WinningLine.Row0)" />
+        <line x1="0" y1="120" x2="240" y2="120" class="@LineClass(WinningLine.Row1)" />
+        <line x1="0" y1="200" x2="240" y2="200" class="@LineClass(WinningLine.Row2)" />
+        <line x1="40" y1="0" x2="40" y2="240" class="@LineClass(WinningLine.Col0)" />
+        <line x1="120" y1="0" x2="120" y2="240" class="@LineClass(WinningLine.Col1)" />
+        <line x1="200" y1="0" x2="200" y2="240" class="@LineClass(WinningLine.Col2)" />
+        <line x1="0" y1="0" x2="240" y2="240" class="@LineClass(WinningLine.DiagonalMain)" />
+        <line x1="0" y1="240" x2="240" y2="0" class="@LineClass(WinningLine.DiagonalAnti)" />
+    </svg>
 </div>
 
 @code {
     private readonly string[] cells = new string[9];
     private string statusText = string.Empty;
     private bool isHumanVsAi = true;
+    private WinningLine winningLine = WinningLine.None;
 
     protected override void OnInitialized()
     {
@@ -67,7 +74,12 @@
                 _ => "Draw"
             }
             : $"Turn: {Game.Board.CurrentPlayer}";
+        winningLine = Game.Board.IsGameOver && Game.Board.Winner is Player winner
+            ? FindWinningLine(Game.Board, winner)
+            : WinningLine.None;
     }
+
+    private string LineClass(WinningLine line) => winningLine == line ? "visible" : string.Empty;
 
     private static Move ToMove(int index) => new(index / 3, index % 3);
 
@@ -77,4 +89,40 @@
         Player.O => "O",
         _ => string.Empty
     };
+
+    private static WinningLine FindWinningLine(Board board, Player player)
+    {
+        for (var i = 0; i < 3; i++)
+        {
+            if (board[i, 0] == player && board[i, 1] == player && board[i, 2] == player)
+            {
+                return i switch
+                {
+                    0 => WinningLine.Row0,
+                    1 => WinningLine.Row1,
+                    _ => WinningLine.Row2,
+                };
+            }
+            if (board[0, i] == player && board[1, i] == player && board[2, i] == player)
+            {
+                return i switch
+                {
+                    0 => WinningLine.Col0,
+                    1 => WinningLine.Col1,
+                    _ => WinningLine.Col2,
+                };
+            }
+        }
+
+        if (board[0, 0] == player && board[1, 1] == player && board[2, 2] == player)
+        {
+            return WinningLine.DiagonalMain;
+        }
+        if (board[0, 2] == player && board[1, 1] == player && board[2, 0] == player)
+        {
+            return WinningLine.DiagonalAnti;
+        }
+
+        return WinningLine.None;
+    }
 }

--- a/apps/TicTacToe.Blazor/Pages/Index.razor
+++ b/apps/TicTacToe.Blazor/Pages/Index.razor
@@ -1,2 +1,2 @@
 @page "/"
-<h1>Hello</h1>
+<TicTacToeBoard />

--- a/apps/TicTacToe.Blazor/Pages/_Host.cshtml
+++ b/apps/TicTacToe.Blazor/Pages/_Host.cshtml
@@ -7,6 +7,7 @@
     <meta charset="utf-8" />
     <title>TicTacToeVibe</title>
     <base href="~/" />
+    <link href="css/app.css" rel="stylesheet" />
 </head>
 <body>
     <app>

--- a/apps/TicTacToe.Blazor/Shared/MainLayout.razor
+++ b/apps/TicTacToe.Blazor/Shared/MainLayout.razor
@@ -1,7 +1,4 @@
 @inherits LayoutComponentBase
-<div class="sidebar">
-    <NavMenu />
-</div>
 <div class="main">
     @Body
 </div>

--- a/apps/TicTacToe.Blazor/WinningLine.cs
+++ b/apps/TicTacToe.Blazor/WinningLine.cs
@@ -1,0 +1,17 @@
+namespace TicTacToeVibe.Blazor;
+
+/// <summary>
+/// Possible winning line positions on the Tic-Tac-Toe board.
+/// </summary>
+public enum WinningLine
+{
+    None,
+    Row0,
+    Row1,
+    Row2,
+    Col0,
+    Col1,
+    Col2,
+    DiagonalMain,
+    DiagonalAnti
+}

--- a/apps/TicTacToe.Blazor/wwwroot/css/app.css
+++ b/apps/TicTacToe.Blazor/wwwroot/css/app.css
@@ -1,0 +1,93 @@
+:root {
+  --color-background: #0F1116;
+  --color-surface: #171B22;
+  --color-surface-hover: #1E2430;
+  --color-surface-pressed: #11151C;
+  --color-accent: #4F8CFF;
+  --color-accent-muted: #2F5FB8;
+  --color-text: #E6EAF2;
+  --color-text-muted: #A9B0BD;
+}
+
+body {
+  background-color: var(--color-background);
+  color: var(--color-text);
+  font-family: 'Segoe UI', sans-serif;
+  margin: 0;
+}
+
+.main {
+  padding: 12px;
+}
+
+.controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+button {
+  background-color: var(--color-surface);
+  color: var(--color-text);
+  border: 1px solid transparent;
+  border-radius: 12px;
+  padding: 10px 16px;
+  cursor: pointer;
+}
+
+button:hover:not(:disabled) {
+  background-color: var(--color-surface-hover);
+  border-color: var(--color-accent);
+}
+
+button:active:not(:disabled) {
+  background-color: var(--color-surface-pressed);
+  border-color: var(--color-accent-muted);
+}
+
+button:disabled {
+  background-color: #12151B;
+  border-color: #20242C;
+  color: var(--color-text-muted);
+  cursor: default;
+}
+
+.board {
+  position: relative;
+  width: 240px;
+  height: 240px;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: repeat(3, 1fr);
+  gap: 8px;
+}
+
+.cell {
+  font-size: 32px;
+  min-width: 72px;
+  min-height: 72px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.win-lines {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 240px;
+  height: 240px;
+  pointer-events: none;
+}
+
+.win-lines line {
+  stroke: var(--color-accent);
+  stroke-width: 6;
+  visibility: hidden;
+  filter: drop-shadow(0 0 10px var(--color-accent));
+}
+
+.win-lines line.visible {
+  visibility: visible;
+}


### PR DESCRIPTION
## Summary
- Show TicTacToe board on startup instead of Hello page
- Apply WPF-inspired dark theme and hover effects
- Draw neon line over the winning combination

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfae676148332bc05c0a87ed9ec2f