### PR TITLE
Handle missing AI service in Blazor board

### DIFF
--- a/apps/TicTacToe.Blazor/Components/TicTacToeBoard.razor
+++ b/apps/TicTacToe.Blazor/Components/TicTacToeBoard.razor
@@ -1,6 +1,6 @@
 @using TicTacToeVibe.Core
 @inject IGameService Game
-@inject IComputerPlayer Ai
+@inject IComputerPlayer? Ai
 
 <div class="controls">
     <input type="checkbox" @bind="isHumanVsAi" /> Human vs AI
@@ -40,7 +40,7 @@
         if (Game.Play(ToMove(index)))
         {
             UpdateState();
-            if (isHumanVsAi && !Game.Board.IsGameOver)
+            if (isHumanVsAi && Ai is not null && !Game.Board.IsGameOver)
             {
                 var move = Ai.ChooseMove(Game.Board.Clone());
                 if (move.HasValue)


### PR DESCRIPTION
## Summary
- Avoid null reference when playing against AI in Blazor by checking that the AI service is available

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfce9d29483329c788daf633fbc9d