### PR TITLE
Fix compile errors in GameScreen

### DIFF
--- a/Android/app/src/main/java/com/alexgold25/tictactoevibe/ui/GameScreen.kt
+++ b/Android/app/src/main/java/com/alexgold25/tictactoevibe/ui/GameScreen.kt
@@ -18,7 +18,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
-import androidx.compose.ui.input.pointer.pointerMoveFilter
+import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
@@ -56,16 +58,12 @@ fun GameScreen(modifier: Modifier = Modifier) {
                                         if (isHovered) MaterialTheme.colorScheme.surfaceVariant
                                         else MaterialTheme.colorScheme.surface
                                     )
-                                    .pointerMoveFilter(
-                                        onEnter = {
-                                            hovered = r to c
-                                            false
-                                        },
-                                        onExit = {
-                                            hovered = null
-                                            false
-                                        }
-                                    )
+                                    .onPointerEvent(PointerEventType.Enter) {
+                                        hovered = r to c
+                                    }
+                                    .onPointerEvent(PointerEventType.Exit) {
+                                        hovered = null
+                                    }
                                     .clickable(enabled = cell == null && winInfo == null) {
                                         board = board.mapIndexed { row, cols ->
                                             cols.mapIndexed { col, value ->


### PR DESCRIPTION
## Summary
- replace removed `pointerMoveFilter` with `onPointerEvent`
- import `nativeCanvas` and pointer event utilities

## Testing
- `./gradlew :app:compileDebugKotlin` *(fails: Unable to tunnel through proxy; HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68be0ce4b0948332b9a3acde800e8471