### PR TITLE
Fix pointer event handling for GameScreen

### DIFF
--- a/Android/app/src/main/java/com/alexgold25/tictactoevibe/ui/GameScreen.kt
+++ b/Android/app/src/main/java/com/alexgold25/tictactoevibe/ui/GameScreen.kt
@@ -20,9 +20,7 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.input.pointer.PointerEventType
-import androidx.compose.ui.input.pointer.awaitPointerEvent
-import androidx.compose.ui.input.pointer.awaitPointerEventScope
-import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
@@ -60,17 +58,11 @@ fun GameScreen(modifier: Modifier = Modifier) {
                                         if (isHovered) MaterialTheme.colorScheme.surfaceVariant
                                         else MaterialTheme.colorScheme.surface
                                     )
-                                    .pointerInput(Unit) {
-                                        awaitPointerEventScope {
-                                            while (true) {
-                                                val event = awaitPointerEvent()
-                                                when (event.type) {
-                                                    PointerEventType.Enter -> hovered = r to c
-                                                    PointerEventType.Exit -> hovered = null
-                                                    else -> {}
-                                                }
-                                            }
-                                        }
+                                    .onPointerEvent(PointerEventType.Enter) {
+                                        hovered = r to c
+                                    }
+                                    .onPointerEvent(PointerEventType.Exit) {
+                                        hovered = null
                                     }
                                     .clickable(enabled = cell == null && winInfo == null) {
                                         board = board.mapIndexed { row, cols ->


### PR DESCRIPTION
## Summary
- replace deprecated pointer input APIs with `onPointerEvent` handlers to resolve build failure

## Testing
- `./gradlew :app:assembleDebug` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68be0f0945c48332be3d83e07f750f10