### PR TITLE
Replace pointer hover API for Compose compatibility

### DIFF
--- a/Android/app/src/main/java/com/alexgold25/tictactoevibe/ui/GameScreen.kt
+++ b/Android/app/src/main/java/com/alexgold25/tictactoevibe/ui/GameScreen.kt
@@ -19,8 +19,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.nativeCanvas
-import androidx.compose.ui.input.pointer.PointerEventType
-import androidx.compose.ui.input.pointer.onPointerEvent
+import androidx.compose.ui.input.pointer.pointerMoveFilter
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
@@ -58,12 +57,16 @@ fun GameScreen(modifier: Modifier = Modifier) {
                                         if (isHovered) MaterialTheme.colorScheme.surfaceVariant
                                         else MaterialTheme.colorScheme.surface
                                     )
-                                    .onPointerEvent(PointerEventType.Enter) {
-                                        hovered = r to c
-                                    }
-                                    .onPointerEvent(PointerEventType.Exit) {
-                                        hovered = null
-                                    }
+                                    .pointerMoveFilter(
+                                        onEnter = {
+                                            hovered = r to c
+                                            false
+                                        },
+                                        onExit = {
+                                            hovered = null
+                                            false
+                                        }
+                                    )
                                     .clickable(enabled = cell == null && winInfo == null) {
                                         board = board.mapIndexed { row, cols ->
                                             cols.mapIndexed { col, value ->


### PR DESCRIPTION
## Summary
- replace deprecated `onPointerEvent` usage with `pointerMoveFilter` in GameScreen

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68be0fba3d9083329c8f7916338db92c