### PR TITLE
Improve minimax AI to prioritize immediate wins

### DIFF
--- a/libs/TicTacToe.Core/MinimaxAi.cs
+++ b/libs/TicTacToe.Core/MinimaxAi.cs
@@ -23,7 +23,7 @@ public sealed class MinimaxAi : IComputerPlayer
         {
             var clone = board.Clone();
             clone.TryApply(move);
-            var score = Minimax(clone, false, int.MinValue, int.MaxValue, board.CurrentPlayer);
+            var score = Minimax(clone, false, int.MinValue, int.MaxValue, board.CurrentPlayer, 1);
             if (score > bestScore)
             {
                 bestScore = score;
@@ -72,19 +72,19 @@ public sealed class MinimaxAi : IComputerPlayer
         }
     }
 
-    private static int Minimax(Board board, bool maximizing, int alpha, int beta, Player ai)
+    private static int Minimax(Board board, bool maximizing, int alpha, int beta, Player ai, int depth)
     {
         if (board.IsGameOver)
         {
             if (board.Winner == ai)
             {
-                return 1;
+                return 10 - depth;
             }
             if (board.Winner is null)
             {
                 return 0;
             }
-            return -1;
+            return depth - 10;
         }
 
         if (maximizing)
@@ -94,7 +94,7 @@ public sealed class MinimaxAi : IComputerPlayer
             {
                 var clone = board.Clone();
                 clone.TryApply(move);
-                value = Math.Max(value, Minimax(clone, false, alpha, beta, ai));
+                value = Math.Max(value, Minimax(clone, false, alpha, beta, ai, depth + 1));
                 alpha = Math.Max(alpha, value);
                 if (alpha >= beta)
                 {
@@ -110,7 +110,7 @@ public sealed class MinimaxAi : IComputerPlayer
             {
                 var clone = board.Clone();
                 clone.TryApply(move);
-                value = Math.Min(value, Minimax(clone, true, alpha, beta, ai));
+                value = Math.Min(value, Minimax(clone, true, alpha, beta, ai, depth + 1));
                 beta = Math.Min(beta, value);
                 if (alpha >= beta)
                 {

--- a/tests/TicTacToe.Core.Tests/GameTests.cs
+++ b/tests/TicTacToe.Core.Tests/GameTests.cs
@@ -101,4 +101,17 @@ public class GameTests
         // O can win by playing (1,2)
         ai.ChooseMove(board).Should().Be(new Move(1,2));
     }
+
+    [Fact]
+    public void AiChoosesImmediateWinOverDelayedWin()
+    {
+        var board = new Board();
+        board.TryApply(new Move(0,0)); // X
+        board.TryApply(new Move(1,0)); // O
+        board.TryApply(new Move(0,1)); // X
+        board.TryApply(new Move(2,0)); // O
+        var ai = new MinimaxAi();
+        // X can win immediately at (0,2) but center also leads to a win later
+        ai.ChooseMove(board).Should().Be(new Move(0,2));
+    }
 }


### PR DESCRIPTION
## Summary
- refine minimax scoring with depth to favor quick victories and delay losses
- add regression test ensuring the AI selects an available immediate win

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be1bcc11c88332b1b2782044a8175d