### PR TITLE
Improve Android AI engine

### DIFF
--- a/Android/app/src/test/java/com/alexgold25/tictactoevibe/AiEngineTest.kt
+++ b/Android/app/src/test/java/com/alexgold25/tictactoevibe/AiEngineTest.kt
@@ -1,0 +1,28 @@
+package com.alexgold25.tictactoevibe
+
+import com.alexgold25.tictactoevibe.ui.bestMove
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AiEngineTest {
+    @Test
+    fun aiBlocksImmediateThreat() {
+        val board = listOf<String?>(
+            "X", "X", null,
+            null, "O", null,
+            null, null, null
+        )
+        assertEquals(2, bestMove(board))
+    }
+
+    @Test
+    fun aiWinsWhenPossible() {
+        val board = listOf<String?>(
+            "X", null, null,
+            "O", "O", null,
+            "X", "X", null
+        )
+        assertEquals(5, bestMove(board))
+    }
+}
+


### PR DESCRIPTION
## Summary
- Refactor Android AI logic into reusable functions
- Implement depth-aware minimax with alpha-beta pruning for smarter moves
- Add unit tests ensuring AI blocks threats and takes winning plays

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*
- `dotnet test` *(fails: command not found; apt-get update 403 when attempting to install)*

------
https://chatgpt.com/codex/tasks/task_e_68be1cbd8e748332862f014208fd5161